### PR TITLE
Add missing --custom-modules command to example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Follow the steps below to run the Migration toolkit:
     * The following example shows the command with all parameters for complete migration:
 
         ```powershell
-        Migration.Toolkit.CLI.exe  migrate --sites --users --settings-keys --page-types --pages --attachments --contact-management --forms --media-libraries --data-protection --countries
+        Migration.Toolkit.CLI.exe  migrate --sites --custom-modules --users --settings-keys --page-types --pages --attachments --contact-management --forms --media-libraries --data-protection --countries
         ```
 
 8. Observe the command line output. The command output is also stored in a log file (`logs\log-<date>.txt` under the output directory by default), which you can review later.


### PR DESCRIPTION
### Motivation

Corrects the example command for running a complete migration, current command will produce:

```
Source instance version 13 detected
Migration --users needs to run migration --custom-modules before.
Migration --contact-management needs to run migration --custom-modules before.
Migration --forms needs to run migration --custom-modules before.
Migration --media-libraries needs to run migration --custom-modules before.
```

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
